### PR TITLE
Don't log if timestamp is 0

### DIFF
--- a/src/server/services/dao.js
+++ b/src/server/services/dao.js
@@ -56,7 +56,10 @@ dao.saveUsers = function(users) {
         if (!db.object.users[user.userId]) {
             db.object.users[user.userId] = [];
         }
-        db.object.users[user.userId].push(user.timestamp);
+        
+        if(user.timestamp) {
+            db.object.users[user.userId].push(user.timestamp);
+        }
     });
     db.write();
 };


### PR DESCRIPTION
I don't know what causes this. But sometimes timestamp value is 0. And it messes up the graph.

So, if we don't log it, it should be fine.